### PR TITLE
Add field ContractCallInput.AllowInitFunction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# ctags file
+tags

--- a/input.go
+++ b/input.go
@@ -94,4 +94,8 @@ type ContractCallInput struct {
 	// Function is the name of the smart contract function that will be called.
 	// The function must be public (e.g. in Iele `define public @functionName(...)`)
 	Function string
+
+	// AllowInitFunction specifies whether calling the initialization method of
+	// the smart contract is allowed or not
+	AllowInitFunction bool
 }


### PR DESCRIPTION
This PR adds the field `ContractCallInput.AllowInitFunction`, a boolean used to determine whether indirect calls are allowed to execute the `init()` function of a SC. 

Adding this field to `ContractCallInput` simplifies indirect deployment and upgrade in Arwen.