### PR TITLE
Fix log `ESDTNFTCreate`

### DIFF
--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -203,8 +203,7 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 		},
 	}
 
-	var esdtDataBytes []byte
-	esdtDataBytes, err = e.esdtStorageHandler.SaveESDTNFTToken(accountWithRoles.AddressBytes(), accountWithRoles, esdtTokenKey, nextNonce, esdtData, true, vmInput.ReturnCallAfterError)
+	_, err = e.esdtStorageHandler.SaveESDTNFTToken(accountWithRoles.AddressBytes(), accountWithRoles, esdtTokenKey, nextNonce, esdtData, true, vmInput.ReturnCallAfterError)
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +228,11 @@ func (e *esdtNFTCreate) ProcessBuiltinFunction(
 		ReturnCode:   vmcommon.Ok,
 		GasRemaining: vmInput.GasProvided - gasToUse,
 		ReturnData:   [][]byte{big.NewInt(0).SetUint64(nextNonce).Bytes()},
+	}
+
+	esdtDataBytes, err := e.marshaller.Marshal(esdtData)
+	if err != nil {
+		log.Warn("esdtNFTCreate.ProcessBuiltinFunction: cannot marshall esdt data for log", "error", err)
 	}
 
 	addESDTEntryInVMOutput(vmOutput, []byte(core.BuiltInFunctionESDTNFTCreate), vmInput.Arguments[0], nextNonce, quantity, vmInput.CallerAddr, esdtDataBytes)

--- a/builtInFunctions/esdtNFTCreate_test.go
+++ b/builtInFunctions/esdtNFTCreate_test.go
@@ -316,6 +316,11 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionShouldWork(t *testing.T) {
 	esdtData, _, _ := esdtDataStorage.getESDTDigitalTokenDataFromSystemAccount(tokenKey)
 	assert.Equal(t, tokenMetaData, esdtData.TokenMetaData)
 	assert.Equal(t, esdtData.Value, quantity)
+
+	esdtDataBytes := vmOutput.Logs[0].Topics[3]
+	var esdtDataFromLog esdt.ESDigitalToken
+	_ = nftCreate.marshaller.Unmarshal(&esdtDataFromLog, esdtDataBytes)
+	require.Equal(t, esdtData.TokenMetaData, esdtDataFromLog.TokenMetaData)
 }
 
 func TestEsdtNFTCreate_ProcessBuiltinFunctionWithExecByCaller(t *testing.T) {


### PR DESCRIPTION
- Fixed log that is generated when a new NFT / SFT or MetaESDT is created