### PR TITLE
[BUG_FIX] Datafield parser nft transfer

### DIFF
--- a/parsers/dataField/parseMultiESDTNFTTransfer_test.go
+++ b/parsers/dataField/parseMultiESDTNFTTransfer_test.go
@@ -73,4 +73,14 @@ func TestMultiESDTNFTTransferParse(t *testing.T) {
 			Operation: "MultiESDTNFTTransfer",
 		}, res)
 	})
+
+	t.Run("MultiNFTTransferWrongReceiverAddressFromDataField", func(t *testing.T) {
+		t.Parallel()
+
+		dataField := []byte("MultiESDTNFTTransfer@000000000000000005001e2a1428dd1e3a5146b3960d9e0f4a50369904@02@4d4949552d61626364@00@01@4d4949552d616263646566@02@05")
+		res := parser.Parse(dataField, sender, sender, 3)
+		require.Equal(t, &ResponseParseData{
+			Operation: "MultiESDTNFTTransfer",
+		}, res)
+	})
 }

--- a/parsers/dataField/parseSingleNFTTransfer.go
+++ b/parsers/dataField/parseSingleNFTTransfer.go
@@ -32,6 +32,11 @@ func (odp *operationDataFieldParser) parseSingleESDTNFTTransfer(args [][]byte, f
 
 	responseParse.Tokens = append(responseParse.Tokens, token)
 	responseParse.ESDTValues = append(responseParse.ESDTValues, esdtNFTTransfer.ESDTValue.String())
+
+	if len(rcvAddr) != len(sender) {
+		return responseParse
+	}
+
 	responseParse.Receivers = append(responseParse.Receivers, rcvAddr)
 	responseParse.ReceiversShardID = append(responseParse.ReceiversShardID, receiverShardID)
 

--- a/parsers/dataField/parseSingleNFTTransfer_test.go
+++ b/parsers/dataField/parseSingleNFTTransfer_test.go
@@ -87,4 +87,16 @@ func TestESDTNFTTransfer(t *testing.T) {
 			ReceiversShardID: []uint32{0},
 		}, res)
 	})
+
+	t.Run("NFTTransferWrongReceiverAddressFromDataField", func(t *testing.T) {
+		t.Parallel()
+		dataField := []byte("ESDTNFTTransfer@54455354312d373563613361@01@01@")
+		res := parser.Parse(dataField, sender, sender, 3)
+		require.Equal(t, &ResponseParseData{
+			Operation:  "ESDTNFTTransfer",
+			ESDTValues: []string{"1"},
+			Tokens:     []string{"TEST1-75ca3a-01"},
+		}, res)
+
+	})
 }


### PR DESCRIPTION
- Fixed how an NFT transfer  is parsed in case of a wrong receiver address in the data field