### PR TITLE
Removed EncodeBytesSlice()

### DIFF
--- a/builtInFunctions/esdtNFTCreate.go
+++ b/builtInFunctions/esdtNFTCreate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
 	"github.com/ElrondNetwork/elrond-go-core/data/vm"
 	logger "github.com/ElrondNetwork/elrond-go-logger"
-	"github.com/ElrondNetwork/elrond-vm-common"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elrond-vm-common
 go 1.13
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.7
+	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108131533-15ef756cddb2
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ElrondNetwork/elrond-vm-common
 go 1.13
 
 require (
-	github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108131533-15ef756cddb2
+	github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221114131354-7a10b0122311
 	github.com/ElrondNetwork/elrond-go-logger v1.0.7
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
-github.com/ElrondNetwork/elrond-go-core v1.1.7 h1:pusBmtsS7lUzrDovW7XKWwhXIt3xRQg5hsB5bV8GkZQ=
-github.com/ElrondNetwork/elrond-go-core v1.1.7/go.mod h1:O9FkkTT2H9kxCzfn40TbhoCDXzGmUrRVusMomhK/Y3g=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108131533-15ef756cddb2 h1:coHmiMGNDIgPOsgxMJDJxuJvTgY0Pd364a1WLlYFAy8=
+github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108131533-15ef756cddb2/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei04gsMvyjL05X6mE=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=
@@ -34,6 +34,7 @@ github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/ElrondNetwork/elrond-go-core v1.0.0/go.mod h1:FQMem7fFF4+8pQ6lVsBZq6yO+smD0nV23P4bJpmPjTo=
 github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108131533-15ef756cddb2 h1:coHmiMGNDIgPOsgxMJDJxuJvTgY0Pd364a1WLlYFAy8=
 github.com/ElrondNetwork/elrond-go-core v1.1.24-0.20221108131533-15ef756cddb2/go.mod h1:Yz8JK5sGBctw7+gU8j2mZHbzQ09Ek4XHJ4Uinq1N6nM=
+github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221114131354-7a10b0122311 h1:It+2XCbsj4JdmU1/AbRvnIwHOHrG1DDNEpgcVRkcqjk=
+github.com/ElrondNetwork/elrond-go-core v1.1.25-0.20221114131354-7a10b0122311/go.mod h1:UcZAiUqKBv3M3U6pJkYqIAx4OKubLYIc0QBVN+bY29g=
 github.com/ElrondNetwork/elrond-go-logger v1.0.4/go.mod h1:e5D+c97lKUfFdAzFX7rrI2Igl/z4Y0RkKYKWyzprTGk=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7 h1:Ldl1rVS0RGKc1IsW8jIaGCb6Zwei04gsMvyjL05X6mE=
 github.com/ElrondNetwork/elrond-go-logger v1.0.7/go.mod h1:cBfgx0ST/CJx8jrxJSC5aiSrvkGzcnF7sK06RD8mFxQ=

--- a/parsers/dataField/parseSingleNFTTransfer_test.go
+++ b/parsers/dataField/parseSingleNFTTransfer_test.go
@@ -11,7 +11,7 @@ import (
 
 var log = logger.GetOrCreate("parse-tests")
 
-var pubKeyConv, _ = pubkeyConverter.NewBech32PubkeyConverter(32, log)
+var pubKeyConv, _ = pubkeyConverter.NewBech32PubkeyConverter(32, "erd")
 
 var sender, _ = pubKeyConv.Decode("erd1kqdm94ef5dr9nz3208rrsdzkgwkz53saj4t5chx26cm4hlq8qz8qqd9207")
 var receiver, _ = pubKeyConv.Decode("erd1kszzq4egxj5m3t22vt2s8vplmxmqrstghecmnk3tq9mn5fdy7pqqgvzkug")

--- a/parsers/dataField/utils.go
+++ b/parsers/dataField/utils.go
@@ -64,20 +64,6 @@ func isBuiltInFunction(builtInFunctionsList []string, function string) bool {
 	return false
 }
 
-// EncodeBytesSlice will encode the provided bytes slice with a provided function
-func EncodeBytesSlice(encodeFunc func(b []byte) string, rcvs [][]byte) []string {
-	if encodeFunc == nil {
-		return nil
-	}
-
-	encodedSlice := make([]string, 0, len(rcvs))
-	for _, rcv := range rcvs {
-		encodedSlice = append(encodedSlice, encodeFunc(rcv))
-	}
-
-	return encodedSlice
-}
-
 func computeTokenIdentifier(token string, nonce uint64) string {
 	if token == "" || nonce == 0 {
 		return ""

--- a/parsers/dataField/utils_test.go
+++ b/parsers/dataField/utils_test.go
@@ -33,18 +33,3 @@ func TestIsASCIIString(t *testing.T) {
 	require.False(t, isASCIIString(string([]byte{12, 255})))
 	require.False(t, isASCIIString(string([]byte{12, 188})))
 }
-
-func TestEncodeBytesSlice(t *testing.T) {
-	t.Parallel()
-
-	res := EncodeBytesSlice(nil, [][]byte{[]byte("something")})
-	require.Equal(t, 0, len(res))
-
-	encodeFunc := func(i []byte) string {
-		return hex.EncodeToString(i)
-	}
-
-	res = EncodeBytesSlice(encodeFunc, [][]byte{[]byte("something")})
-	require.Equal(t, 1, len(res))
-	require.Equal(t, "736f6d657468696e67", res[0])
-}

--- a/returnCodes.go
+++ b/returnCodes.go
@@ -29,6 +29,8 @@ func (rc ReturnCode) String() string {
 		return "contract invalid"
 	case ExecutionFailed:
 		return "execution failed"
+	case EncodingFailed:
+		return "address encoding failed"
 	default:
 		return fmt.Sprintf("unknown error, code: %d", rc)
 	}
@@ -73,4 +75,7 @@ const (
 
 	// SimulateFailed is returned when tx simulation fails execution
 	SimulateFailed ReturnCode = 12
+
+	// EncodingFailed is returned when an address encoding fails
+	EncodingFailed ReturnCode = 13
 )


### PR DESCRIPTION
Changes on this repo are triggered by the refactoring of the `PubkeyConverter` refactoring:
- Given the fact that this method was not used in the `/elrond-vm-common` repo at all, it makes sense to have it as a method of the Converter from `/elrond-go-core`, therefore it was moved there.
- After refactoring of the `PubKeyConverter` from `/elrond-go-core` repo, there is no need to use a logger anymore but e `prefix`.