### PR TITLE
En 13529 get token with custom accounts adapter

### DIFF
--- a/builtInFunctions/esdtDataStorage.go
+++ b/builtInFunctions/esdtDataStorage.go
@@ -15,6 +15,15 @@ import (
 
 const existsOnShard = byte(1)
 
+type queryOptions struct {
+	isCustomAccountsAdapterSet bool
+	accountsAdapter            vmcommon.AccountsAdapter
+}
+
+func defaultQueryOptions() queryOptions {
+	return queryOptions{}
+}
+
 type esdtDataStorage struct {
 	accounts              vmcommon.AccountsAdapter
 	globalSettingsHandler vmcommon.ESDTGlobalSettingsHandler
@@ -88,6 +97,33 @@ func (e *esdtDataStorage) GetESDTNFTTokenOnDestination(
 	esdtTokenKey []byte,
 	nonce uint64,
 ) (*esdt.ESDigitalToken, bool, error) {
+	return e.getESDTNFTTokenOnDestinationWithAccountsAdapterOptions(accnt, esdtTokenKey, nonce, defaultQueryOptions())
+}
+
+// GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter gets the nft token on destination account by using a custom accounts adapter
+func (e *esdtDataStorage) GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(
+	accnt vmcommon.UserAccountHandler,
+	esdtTokenKey []byte,
+	nonce uint64,
+	accountsAdapter vmcommon.AccountsAdapter,
+) (*esdt.ESDigitalToken, bool, error) {
+	if check.IfNil(accountsAdapter) {
+		return nil, false, ErrNilAccountsAdapter
+	}
+
+	queryOpts := queryOptions{
+		isCustomAccountsAdapterSet: true,
+		accountsAdapter:            accountsAdapter,
+	}
+	return e.getESDTNFTTokenOnDestinationWithAccountsAdapterOptions(accnt, esdtTokenKey, nonce, queryOpts)
+}
+
+func (e *esdtDataStorage) getESDTNFTTokenOnDestinationWithAccountsAdapterOptions(
+	accnt vmcommon.UserAccountHandler,
+	esdtTokenKey []byte,
+	nonce uint64,
+	options queryOptions,
+) (*esdt.ESDigitalToken, bool, error) {
 	esdtNFTTokenKey := computeESDTNFTTokenKey(esdtTokenKey, nonce)
 	esdtData := &esdt.ESDigitalToken{
 		Value: big.NewInt(0),
@@ -107,7 +143,7 @@ func (e *esdtDataStorage) GetESDTNFTTokenOnDestination(
 		return esdtData, false, nil
 	}
 
-	esdtMetaData, err := e.getESDTMetaDataFromSystemAccount(esdtNFTTokenKey)
+	esdtMetaData, err := e.getESDTMetaDataFromSystemAccount(esdtNFTTokenKey, options)
 	if err != nil {
 		return nil, false, err
 	}
@@ -120,8 +156,9 @@ func (e *esdtDataStorage) GetESDTNFTTokenOnDestination(
 
 func (e *esdtDataStorage) getESDTDigitalTokenDataFromSystemAccount(
 	tokenKey []byte,
+	options queryOptions,
 ) (*esdt.ESDigitalToken, vmcommon.UserAccountHandler, error) {
-	systemAcc, err := e.getSystemAccount()
+	systemAcc, err := e.getSystemAccount(options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -142,8 +179,9 @@ func (e *esdtDataStorage) getESDTDigitalTokenDataFromSystemAccount(
 
 func (e *esdtDataStorage) getESDTMetaDataFromSystemAccount(
 	tokenKey []byte,
+	options queryOptions,
 ) (*esdt.MetaData, error) {
-	esdtData, _, err := e.getESDTDigitalTokenDataFromSystemAccount(tokenKey)
+	esdtData, _, err := e.getESDTDigitalTokenDataFromSystemAccount(tokenKey, options)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +267,7 @@ func (e *esdtDataStorage) AddToLiquiditySystemAcc(
 	}
 
 	esdtNFTTokenKey := computeESDTNFTTokenKey(esdtTokenKey, nonce)
-	esdtData, systemAcc, err := e.getESDTDigitalTokenDataFromSystemAccount(esdtNFTTokenKey)
+	esdtData, systemAcc, err := e.getESDTDigitalTokenDataFromSystemAccount(esdtNFTTokenKey, defaultQueryOptions())
 	if err != nil {
 		return err
 	}
@@ -338,7 +376,7 @@ func (e *esdtDataStorage) saveESDTMetaDataToSystemAccount(
 		return nil
 	}
 
-	systemAcc, err := e.getSystemAccount()
+	systemAcc, err := e.getSystemAccount(defaultQueryOptions())
 	if err != nil {
 		return err
 	}
@@ -429,8 +467,13 @@ func (e *esdtDataStorage) marshalAndSaveData(
 	return e.accounts.SaveAccount(systemAcc)
 }
 
-func (e *esdtDataStorage) getSystemAccount() (vmcommon.UserAccountHandler, error) {
-	systemSCAccount, err := e.accounts.LoadAccount(vmcommon.SystemAccountAddress)
+func (e *esdtDataStorage) getSystemAccount(options queryOptions) (vmcommon.UserAccountHandler, error) {
+	accountsAdapter := e.accounts
+	if options.isCustomAccountsAdapterSet && !check.IfNil(options.accountsAdapter) {
+		accountsAdapter = options.accountsAdapter
+	}
+
+	systemSCAccount, err := accountsAdapter.LoadAccount(vmcommon.SystemAccountAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -474,7 +517,7 @@ func (e *esdtDataStorage) WasAlreadySentToDestinationShardAndUpdateState(
 	esdtTokenKey := append(e.keyPrefix, tickerID...)
 	esdtNFTTokenKey := computeESDTNFTTokenKey(esdtTokenKey, nonce)
 
-	esdtData, systemAcc, err := e.getESDTDigitalTokenDataFromSystemAccount(esdtNFTTokenKey)
+	esdtData, systemAcc, err := e.getESDTDigitalTokenDataFromSystemAccount(esdtNFTTokenKey, defaultQueryOptions())
 	if err != nil {
 		return false, err
 	}

--- a/builtInFunctions/esdtDataStorage.go
+++ b/builtInFunctions/esdtDataStorage.go
@@ -115,6 +115,7 @@ func (e *esdtDataStorage) GetESDTNFTTokenOnDestinationWithCustomSystemAccount(
 		isCustomSystemAccountSet: true,
 		customSystemAccount:      customSystemAccount,
 	}
+
 	return e.getESDTNFTTokenOnDestinationWithAccountsAdapterOptions(accnt, esdtTokenKey, nonce, queryOpts)
 }
 
@@ -472,6 +473,10 @@ func (e *esdtDataStorage) getSystemAccount(options queryOptions) (vmcommon.UserA
 		return options.customSystemAccount, nil
 	}
 
+	return e.loadSystemAccount()
+}
+
+func (e *esdtDataStorage) loadSystemAccount() (vmcommon.UserAccountHandler, error) {
 	systemSCAccount, err := e.accounts.LoadAccount(vmcommon.SystemAccountAddress)
 	if err != nil {
 		return nil, err

--- a/builtInFunctions/esdtDataStorage_test.go
+++ b/builtInFunctions/esdtDataStorage_test.go
@@ -165,7 +165,7 @@ func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationGetDataFromSystemAcc(t *tes
 	assert.Equal(t, esdtData, esdtDataGet)
 }
 
-func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(t *testing.T) {
+func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationWithCustomSystemAccount(t *testing.T) {
 	t.Parallel()
 
 	args := createMockArgsForNewESDTDataStorage()
@@ -191,12 +191,12 @@ func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(t
 	esdtMetaDataBytes, _ := args.Marshalizer.Marshal(esdtDataOnSystemAcc)
 	_ = systemAcc.AccountDataHandler().SaveKeyValue(tokenKey, esdtMetaDataBytes)
 
-	customLoadAccountCalled := false
+	retrieveValueFromCustomAccountCalled := false
 	customSystemAccount := &mock.UserAccountStub{
 		AccountDataHandlerCalled: func() vmcommon.AccountDataHandler {
 			return &mock.DataTrieTrackerStub{
 				RetrieveValueCalled: func(key []byte) ([]byte, uint32, error) {
-					customLoadAccountCalled = true
+					retrieveValueFromCustomAccountCalled = true
 					return esdtMetaDataBytes, 0, nil
 				},
 			}
@@ -206,7 +206,7 @@ func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(t
 	assert.Nil(t, err)
 	esdtData.TokenMetaData = metaData
 	assert.Equal(t, esdtData, esdtDataGet)
-	assert.True(t, customLoadAccountCalled)
+	assert.True(t, retrieveValueFromCustomAccountCalled)
 }
 
 func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationMarshalERR(t *testing.T) {

--- a/builtInFunctions/esdtDataStorage_test.go
+++ b/builtInFunctions/esdtDataStorage_test.go
@@ -192,13 +192,17 @@ func TestEsdtDataStorage_GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(t
 	_ = systemAcc.AccountDataHandler().SaveKeyValue(tokenKey, esdtMetaDataBytes)
 
 	customLoadAccountCalled := false
-	customAccountsAdapter := &mock.AccountsStub{
-		LoadAccountCalled: func(address []byte) (vmcommon.AccountHandler, error) {
-			customLoadAccountCalled = true
-			return systemAcc, nil
+	customSystemAccount := &mock.UserAccountStub{
+		AccountDataHandlerCalled: func() vmcommon.AccountDataHandler {
+			return &mock.DataTrieTrackerStub{
+				RetrieveValueCalled: func(key []byte) ([]byte, uint32, error) {
+					customLoadAccountCalled = true
+					return esdtMetaDataBytes, 0, nil
+				},
+			}
 		},
 	}
-	esdtDataGet, _, err := e.GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(userAcc, []byte(key), nonce, customAccountsAdapter)
+	esdtDataGet, _, err := e.GetESDTNFTTokenOnDestinationWithCustomSystemAccount(userAcc, []byte(key), nonce, customSystemAccount)
 	assert.Nil(t, err)
 	esdtData.TokenMetaData = metaData
 	assert.Equal(t, esdtData, esdtDataGet)

--- a/builtInFunctions/esdtNFTAddUri_test.go
+++ b/builtInFunctions/esdtNFTAddUri_test.go
@@ -396,6 +396,6 @@ func TestESDTNFTAddUri_ProcessBuiltinFunctionShouldWork(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey)
+	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	require.Equal(t, metaData.URIs[0], URIToAdd)
 }

--- a/builtInFunctions/esdtNFTCreate_test.go
+++ b/builtInFunctions/esdtNFTCreate_test.go
@@ -344,7 +344,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionShouldWork(t *testing.T) {
 	tokenKey := []byte(baseESDTKeyPrefix + token)
 	tokenKey = append(tokenKey, big.NewInt(1).Bytes()...)
 
-	esdtData, _, _ := esdtDataStorage.getESDTDigitalTokenDataFromSystemAccount(tokenKey)
+	esdtData, _, _ := esdtDataStorage.getESDTDigitalTokenDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	assert.Equal(t, tokenMetaData, esdtData.TokenMetaData)
 	assert.Equal(t, esdtData.Value, quantity)
 
@@ -429,7 +429,7 @@ func TestEsdtNFTCreate_ProcessBuiltinFunctionWithExecByCaller(t *testing.T) {
 	tokenKey := []byte(baseESDTKeyPrefix + token)
 	tokenKey = append(tokenKey, big.NewInt(1).Bytes()...)
 
-	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey)
+	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	assert.Equal(t, tokenMetaData, metaData)
 }
 

--- a/builtInFunctions/updateNFTAttributes_test.go
+++ b/builtInFunctions/updateNFTAttributes_test.go
@@ -395,6 +395,6 @@ func TestESDTNFTUpdateAttributes_ProcessBuiltinFunctionShouldWork(t *testing.T) 
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
-	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey)
+	metaData, _ := esdtDataStorage.getESDTMetaDataFromSystemAccount(tokenKey, defaultQueryOptions())
 	require.Equal(t, metaData.Attributes, newAttributes)
 }

--- a/interface.go
+++ b/interface.go
@@ -288,7 +288,7 @@ type ESDTNFTStorageHandler interface {
 	SaveESDTNFTToken(senderAddress []byte, acnt UserAccountHandler, esdtTokenKey []byte, nonce uint64, esdtData *esdt.ESDigitalToken, isCreation bool, isReturnWithError bool) ([]byte, error)
 	GetESDTNFTTokenOnSender(acnt UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetESDTNFTTokenOnDestination(acnt UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, bool, error)
-	GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(accnt UserAccountHandler, esdtTokenKey []byte, nonce uint64, accountsAdapter AccountsAdapter) (*esdt.ESDigitalToken, bool, error)
+	GetESDTNFTTokenOnDestinationWithCustomSystemAccount(accnt UserAccountHandler, esdtTokenKey []byte, nonce uint64, systemAccount UserAccountHandler) (*esdt.ESDigitalToken, bool, error)
 	WasAlreadySentToDestinationShardAndUpdateState(tickerID []byte, nonce uint64, dstAddress []byte) (bool, error)
 	SaveNFTMetaDataToSystemAccount(tx data.TransactionHandler) error
 	AddToLiquiditySystemAcc(esdtTokenKey []byte, nonce uint64, transferValue *big.Int) error

--- a/interface.go
+++ b/interface.go
@@ -288,6 +288,7 @@ type ESDTNFTStorageHandler interface {
 	SaveESDTNFTToken(senderAddress []byte, acnt UserAccountHandler, esdtTokenKey []byte, nonce uint64, esdtData *esdt.ESDigitalToken, isCreation bool, isReturnWithError bool) ([]byte, error)
 	GetESDTNFTTokenOnSender(acnt UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, error)
 	GetESDTNFTTokenOnDestination(acnt UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, bool, error)
+	GetESDTNFTTokenOnDestinationWithCustomAccountsAdapter(accnt UserAccountHandler, esdtTokenKey []byte, nonce uint64, accountsAdapter AccountsAdapter) (*esdt.ESDigitalToken, bool, error)
 	WasAlreadySentToDestinationShardAndUpdateState(tickerID []byte, nonce uint64, dstAddress []byte) (bool, error)
 	SaveNFTMetaDataToSystemAccount(tx data.TransactionHandler) error
 	AddToLiquiditySystemAcc(esdtTokenKey []byte, nonce uint64, transferValue *big.Int) error

--- a/mock/userAccountStub.go
+++ b/mock/userAccountStub.go
@@ -50,7 +50,7 @@ func (u *UserAccountStub) ClaimDeveloperRewards([]byte) (*big.Int, error) {
 }
 
 // AddToDeveloperReward -
-func (u *UserAccountStub) AddToDeveloperReward(*big.Int) {
+func (u *UserAccountStub) AddToDeveloperReward(_ *big.Int) {
 
 }
 
@@ -122,7 +122,7 @@ func (u *UserAccountStub) GetRootHash() []byte {
 	return nil
 }
 
-// DataTrieTracker -
+// AccountDataHandler -
 func (u *UserAccountStub) AccountDataHandler() vmcommon.AccountDataHandler {
 	if u.AccountDataHandlerCalled != nil {
 		return u.AccountDataHandlerCalled()


### PR DESCRIPTION
added a new function to `esdtDataStorage` that is able to fetch token metadata with a custom system account