### PR TITLE
En 13547 improve nft wipe sys cc liquidity

### DIFF
--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -190,7 +190,7 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.marshaller, true, false)
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, true, false)
 	if err != nil {
 		return err
 	}
@@ -199,7 +199,7 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.marshaller, false, false)
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, false)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.marshaller, false, true)
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, true)
 	if err != nil {
 		return err
 	}

--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -265,7 +265,7 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, true, false)
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.enableEpochsHandler, b.marshaller, true, false)
 	if err != nil {
 		return err
 	}
@@ -274,7 +274,7 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, false)
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.enableEpochsHandler, b.marshaller, false, false)
 	if err != nil {
 		return err
 	}
@@ -283,7 +283,7 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, true)
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.enableEpochsHandler, b.marshaller, false, true)
 	if err != nil {
 		return err
 	}

--- a/builtInFunctions/creator.go
+++ b/builtInFunctions/creator.go
@@ -190,33 +190,6 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 
-	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, true, false)
-	if err != nil {
-		return err
-	}
-	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTFreeze, newFunc)
-	if err != nil {
-		return err
-	}
-
-	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, false)
-	if err != nil {
-		return err
-	}
-	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTUnFreeze, newFunc)
-	if err != nil {
-		return err
-	}
-
-	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, true)
-	if err != nil {
-		return err
-	}
-	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTWipe, newFunc)
-	if err != nil {
-		return err
-	}
-
 	newFunc, err = NewESDTGlobalSettingsFunc(b.accounts, b.marshaller, false, core.BuiltInFunctionESDTUnPause, trueHandler)
 	if err != nil {
 		return err
@@ -288,6 +261,33 @@ func (b *builtInFuncCreator) CreateBuiltInFunctionContainer() error {
 		return err
 	}
 	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTNFTCreate, newFunc)
+	if err != nil {
+		return err
+	}
+
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, true, false)
+	if err != nil {
+		return err
+	}
+	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTFreeze, newFunc)
+	if err != nil {
+		return err
+	}
+
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, false)
+	if err != nil {
+		return err
+	}
+	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTUnFreeze, newFunc)
+	if err != nil {
+		return err
+	}
+
+	newFunc, err = NewESDTFreezeWipeFunc(b.esdtStorageHandler, b.marshaller, false, true)
+	if err != nil {
+		return err
+	}
+	err = b.builtInFunctions.Add(core.BuiltInFunctionESDTWipe, newFunc)
 	if err != nil {
 		return err
 	}

--- a/builtInFunctions/esdtFreezeWipe_test.go
+++ b/builtInFunctions/esdtFreezeWipe_test.go
@@ -15,7 +15,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunctionErrors(t *testing.T) {
 	t.Parallel()
 
 	marshaller := &mock.MarshalizerMock{}
-	freeze, _ := NewESDTFreezeWipeFunc(marshaller, true, false)
+	freeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, true, false)
 	_, err := freeze.ProcessBuiltinFunction(nil, nil, nil)
 	assert.Equal(t, err, ErrNilVmInput)
 
@@ -74,7 +74,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	t.Parallel()
 
 	marshaller := &mock.MarshalizerMock{}
-	freeze, _ := NewESDTFreezeWipeFunc(marshaller, true, false)
+	freeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, true, false)
 	_, err := freeze.ProcessBuiltinFunction(nil, nil, nil)
 	assert.Equal(t, err, ErrNilVmInput)
 
@@ -104,7 +104,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	esdtUserData := ESDTUserMetadataFromBytes(esdtToken.Properties)
 	assert.True(t, esdtUserData.Frozen)
 
-	unFreeze, _ := NewESDTFreezeWipeFunc(marshaller, false, false)
+	unFreeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, false, false)
 	_, err = unFreeze.ProcessBuiltinFunction(nil, acnt, input)
 	assert.Nil(t, err)
 
@@ -115,7 +115,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	assert.False(t, esdtUserData.Frozen)
 
 	// cannot wipe if account is not frozen
-	wipe, _ := NewESDTFreezeWipeFunc(marshaller, false, true)
+	wipe, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, false, true)
 	_, err = wipe.ProcessBuiltinFunction(nil, acnt, input)
 	assert.Equal(t, ErrCannotWipeAccountNotFrozen, err)
 
@@ -133,7 +133,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	err = acnt.AccountDataHandler().SaveKeyValue(esdtKey, esdtTokenBytes)
 	assert.NoError(t, err)
 
-	wipe, _ = NewESDTFreezeWipeFunc(marshaller, false, true)
+	wipe, _ = NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, false, true)
 	vmOutput, err := wipe.ProcessBuiltinFunction(nil, acnt, input)
 	assert.NoError(t, err)
 

--- a/builtInFunctions/esdtFreezeWipe_test.go
+++ b/builtInFunctions/esdtFreezeWipe_test.go
@@ -9,13 +9,14 @@ import (
 	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
 	"github.com/ElrondNetwork/elrond-vm-common/mock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestESDTFreezeWipe_ProcessBuiltInFunctionErrors(t *testing.T) {
 	t.Parallel()
 
 	marshaller := &mock.MarshalizerMock{}
-	freeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, true, false)
+	freeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), &mock.EnableEpochsHandlerStub{}, marshaller, true, false)
 	_, err := freeze.ProcessBuiltinFunction(nil, nil, nil)
 	assert.Equal(t, err, ErrNilVmInput)
 
@@ -74,7 +75,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	t.Parallel()
 
 	marshaller := &mock.MarshalizerMock{}
-	freeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, true, false)
+	freeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), &mock.EnableEpochsHandlerStub{}, marshaller, true, false)
 	_, err := freeze.ProcessBuiltinFunction(nil, nil, nil)
 	assert.Equal(t, err, ErrNilVmInput)
 
@@ -104,7 +105,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	esdtUserData := ESDTUserMetadataFromBytes(esdtToken.Properties)
 	assert.True(t, esdtUserData.Frozen)
 
-	unFreeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, false, false)
+	unFreeze, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), &mock.EnableEpochsHandlerStub{}, marshaller, false, false)
 	_, err = unFreeze.ProcessBuiltinFunction(nil, acnt, input)
 	assert.Nil(t, err)
 
@@ -115,7 +116,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	assert.False(t, esdtUserData.Frozen)
 
 	// cannot wipe if account is not frozen
-	wipe, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, false, true)
+	wipe, _ := NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), &mock.EnableEpochsHandlerStub{}, marshaller, false, true)
 	_, err = wipe.ProcessBuiltinFunction(nil, acnt, input)
 	assert.Equal(t, ErrCannotWipeAccountNotFrozen, err)
 
@@ -133,7 +134,7 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	err = acnt.AccountDataHandler().SaveKeyValue(esdtKey, esdtTokenBytes)
 	assert.NoError(t, err)
 
-	wipe, _ = NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), marshaller, false, true)
+	wipe, _ = NewESDTFreezeWipeFunc(createNewESDTDataStorageHandler(), &mock.EnableEpochsHandlerStub{}, marshaller, false, true)
 	vmOutput, err := wipe.ProcessBuiltinFunction(nil, acnt, input)
 	assert.NoError(t, err)
 
@@ -141,4 +142,64 @@ func TestESDTFreezeWipe_ProcessBuiltInFunction(t *testing.T) {
 	assert.Equal(t, 0, len(marshaledData))
 	assert.Len(t, vmOutput.Logs, 1)
 	assert.Equal(t, [][]byte{key, {}, wipedAmount.Bytes(), []byte("dst")}, vmOutput.Logs[0].Topics)
+}
+
+func TestEsdtFreezeWipe_WipeShouldDecreaseLiquidityIfFlagIsEnabled(t *testing.T) {
+	t.Parallel()
+
+	balance := big.NewInt(37)
+	addToLiquiditySystemAccCalled := false
+	esdtStorage := &mock.ESDTNFTStorageHandlerStub{
+		AddToLiquiditySystemAccCalled: func(_ []byte, _ uint64, transferValue *big.Int) error {
+			require.Equal(t, big.NewInt(0).Neg(balance), transferValue)
+			addToLiquiditySystemAccCalled = true
+			return nil
+		},
+	}
+
+	marshaller := &mock.MarshalizerMock{}
+	wipe, _ := NewESDTFreezeWipeFunc(esdtStorage, &mock.EnableEpochsHandlerStub{}, marshaller, false, true)
+
+	acnt := mock.NewUserAccount([]byte("dst"))
+	metaData := ESDTUserMetadata{Frozen: true}
+	esdtToken := &esdt.ESDigitalToken{
+		Value:      balance,
+		Properties: metaData.ToBytes(),
+	}
+	esdtTokenBytes, _ := marshaller.Marshal(esdtToken)
+
+	nonce := uint64(37)
+	key := append([]byte("MYSFT-0a0a0a"), big.NewInt(int64(nonce)).Bytes()...)
+	esdtKey := append(wipe.keyPrefix, key...)
+
+	err := acnt.AccountDataHandler().SaveKeyValue(esdtKey, esdtTokenBytes)
+	assert.NoError(t, err)
+
+	input := &vmcommon.ContractCallInput{
+		VMInput: vmcommon.VMInput{
+			CallValue: big.NewInt(0),
+		},
+	}
+	input.Arguments = [][]byte{key}
+	input.CallerAddr = core.ESDTSCAddress
+	input.RecipientAddr = []byte("dst")
+
+	acntCopy := acnt.Clone()
+	_, err = wipe.ProcessBuiltinFunction(nil, acntCopy, input)
+	assert.NoError(t, err)
+
+	marshaledData, _, _ := acntCopy.AccountDataHandler().RetrieveValue(esdtKey)
+	assert.Equal(t, 0, len(marshaledData))
+	assert.False(t, addToLiquiditySystemAccCalled)
+
+	wipe.enableEpochsHandler = &mock.EnableEpochsHandlerStub{
+		IsWipeSingleNFTLiquidityDecreaseEnabledField: true,
+	}
+
+	_, err = wipe.ProcessBuiltinFunction(nil, acnt, input)
+	assert.NoError(t, err)
+
+	marshaledData, _, _ = acnt.AccountDataHandler().RetrieveValue(esdtKey)
+	assert.Equal(t, 0, len(marshaledData))
+	assert.True(t, addToLiquiditySystemAccCalled)
 }

--- a/interface.go
+++ b/interface.go
@@ -362,6 +362,7 @@ type EnableEpochsHandler interface {
 	IsESDTNFTImprovementV1FlagEnabled() bool
 	IsFixOldTokenLiquidityEnabled() bool
 	IsRuntimeMemStoreLimitEnabled() bool
+	IsWipeSingleNFTLiquidityDecreaseEnabled() bool
 
 	MultiESDTTransferAsyncCallBackEnableEpoch() uint32
 	FixOOGReturnCodeEnableEpoch() uint32

--- a/mock/enableEpochsHandlerStub.go
+++ b/mock/enableEpochsHandlerStub.go
@@ -30,6 +30,7 @@ type EnableEpochsHandlerStub struct {
 	IsESDTNFTImprovementV1FlagEnabledField               bool
 	IsFixOldTokenLiquidityEnabledField                   bool
 	IsRuntimeMemStoreLimitEnabledField                   bool
+	IsWipeSingleNFTLiquidityDecreaseEnabledField         bool
 	MultiESDTTransferAsyncCallBackEnableEpochField       uint32
 	FixOOGReturnCodeEnableEpochField                     uint32
 	RemoveNonUpdatedStorageEnableEpochField              uint32
@@ -232,6 +233,11 @@ func (stub *EnableEpochsHandlerStub) CheckExecuteReadOnlyEnableEpoch() uint32 {
 // StorageAPICostOptimizationEnableEpoch -
 func (stub *EnableEpochsHandlerStub) StorageAPICostOptimizationEnableEpoch() uint32 {
 	return stub.StorageAPICostOptimizationEnableEpochField
+}
+
+// IsWipeSingleNFTLiquidityDecreaseEnabled -
+func (stub *EnableEpochsHandlerStub) IsWipeSingleNFTLiquidityDecreaseEnabled() bool {
+	return stub.IsWipeSingleNFTLiquidityDecreaseEnabledField
 }
 
 // IsInterfaceNil -

--- a/mock/esdtStorageHandlerStub.go
+++ b/mock/esdtStorageHandlerStub.go
@@ -1,0 +1,81 @@
+package mock
+
+import (
+	"math/big"
+
+	"github.com/ElrondNetwork/elrond-go-core/data"
+	"github.com/ElrondNetwork/elrond-go-core/data/esdt"
+	vmcommon "github.com/ElrondNetwork/elrond-vm-common"
+)
+
+// ESDTNFTStorageHandlerStub -
+type ESDTNFTStorageHandlerStub struct {
+	SaveESDTNFTTokenCalled                                    func(senderAddress []byte, acnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64, esdtData *esdt.ESDigitalToken, isCreation bool, isReturnWithError bool) ([]byte, error)
+	GetESDTNFTTokenOnSenderCalled                             func(acnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, error)
+	GetESDTNFTTokenOnDestinationCalled                        func(acnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, bool, error)
+	GetESDTNFTTokenOnDestinationWithCustomSystemAccountCalled func(accnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64, systemAccount vmcommon.UserAccountHandler) (*esdt.ESDigitalToken, bool, error)
+	WasAlreadySentToDestinationShardAndUpdateStateCalled      func(tickerID []byte, nonce uint64, dstAddress []byte) (bool, error)
+	SaveNFTMetaDataToSystemAccountCalled                      func(tx data.TransactionHandler) error
+	AddToLiquiditySystemAccCalled                             func(esdtTokenKey []byte, nonce uint64, transferValue *big.Int) error
+}
+
+// SaveESDTNFTToken -
+func (stub *ESDTNFTStorageHandlerStub) SaveESDTNFTToken(senderAddress []byte, acnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64, esdtData *esdt.ESDigitalToken, isCreation bool, isReturnWithError bool) ([]byte, error) {
+	if stub.SaveESDTNFTTokenCalled != nil {
+		return stub.SaveESDTNFTTokenCalled(senderAddress, acnt, esdtTokenKey, nonce, esdtData, isCreation, isReturnWithError)
+	}
+	return nil, nil
+}
+
+// GetESDTNFTTokenOnSender -
+func (stub *ESDTNFTStorageHandlerStub) GetESDTNFTTokenOnSender(acnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, error) {
+	if stub.GetESDTNFTTokenOnSenderCalled != nil {
+		return stub.GetESDTNFTTokenOnSenderCalled(acnt, esdtTokenKey, nonce)
+	}
+	return nil, nil
+}
+
+// GetESDTNFTTokenOnDestination -
+func (stub *ESDTNFTStorageHandlerStub) GetESDTNFTTokenOnDestination(acnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64) (*esdt.ESDigitalToken, bool, error) {
+	if stub.GetESDTNFTTokenOnDestinationCalled != nil {
+		return stub.GetESDTNFTTokenOnDestinationCalled(acnt, esdtTokenKey, nonce)
+	}
+	return nil, false, nil
+}
+
+// GetESDTNFTTokenOnDestinationWithCustomSystemAccount -
+func (stub *ESDTNFTStorageHandlerStub) GetESDTNFTTokenOnDestinationWithCustomSystemAccount(accnt vmcommon.UserAccountHandler, esdtTokenKey []byte, nonce uint64, systemAccount vmcommon.UserAccountHandler) (*esdt.ESDigitalToken, bool, error) {
+	if stub.GetESDTNFTTokenOnDestinationWithCustomSystemAccountCalled != nil {
+		return stub.GetESDTNFTTokenOnDestinationWithCustomSystemAccountCalled(accnt, esdtTokenKey, nonce, systemAccount)
+	}
+	return nil, false, nil
+}
+
+// WasAlreadySentToDestinationShardAndUpdateState -
+func (stub *ESDTNFTStorageHandlerStub) WasAlreadySentToDestinationShardAndUpdateState(tickerID []byte, nonce uint64, dstAddress []byte) (bool, error) {
+	if stub.WasAlreadySentToDestinationShardAndUpdateStateCalled != nil {
+		return stub.WasAlreadySentToDestinationShardAndUpdateStateCalled(tickerID, nonce, dstAddress)
+	}
+	return false, nil
+}
+
+// SaveNFTMetaDataToSystemAccount -
+func (stub *ESDTNFTStorageHandlerStub) SaveNFTMetaDataToSystemAccount(tx data.TransactionHandler) error {
+	if stub.SaveNFTMetaDataToSystemAccountCalled != nil {
+		return stub.SaveNFTMetaDataToSystemAccountCalled(tx)
+	}
+	return nil
+}
+
+// AddToLiquiditySystemAcc -
+func (stub *ESDTNFTStorageHandlerStub) AddToLiquiditySystemAcc(esdtTokenKey []byte, nonce uint64, transferValue *big.Int) error {
+	if stub.AddToLiquiditySystemAccCalled != nil {
+		return stub.AddToLiquiditySystemAccCalled(esdtTokenKey, nonce, transferValue)
+	}
+	return nil
+}
+
+// IsInterfaceNil -
+func (stub *ESDTNFTStorageHandlerStub) IsInterfaceNil() bool {
+	return stub == nil
+}


### PR DESCRIPTION
based on the activation flag, system account liquidity should be updated when NFT wipe is successful